### PR TITLE
Compile and run using Java 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ deploy:
   api_key: "$GITHUB_OAUTH_TOKEN"
   file: target/sparcd.jar
   on:
-    repo: CulverLab/sparcd
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: java
 dist: trusty
 jdk:
-- oraclejdk8
+  - openjdk15
 script:
-- jdk_switcher use oraclejdk8
-- cd Sanimal\ FX
-- mvn -U compile package
+  - cd Sanimal\ FX
+  - mvn -U compile package
 
 before_deploy:
   - mv target/SanimalFX-1.0-SNAPSHOT-jar-with-dependencies.jar target/sparcd.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ script:
   - cd Sanimal\ FX
   - mvn -U compile package
 
+cache:
+  directories:
+    - $HOME/.m2
+
 before_deploy:
   - mv target/SanimalFX-1.0-SNAPSHOT-jar-with-dependencies.jar target/sparcd.jar
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: java
 dist: trusty
 jdk:
   - openjdk15
-script:
-  - cd Sanimal\ FX
-  - mvn -U compile package
 
 cache:
   directories:
     - $HOME/.m2
+
+script:
+  - cd Sanimal\ FX
+  - mvn -U compile package
 
 before_deploy:
   - mv target/SanimalFX-1.0-SNAPSHOT-jar-with-dependencies.jar target/sparcd.jar

--- a/Sanimal FX/SanimalFX.iml
+++ b/Sanimal FX/SanimalFX.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_15">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -10,39 +10,55 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.jfxtras:jfxtras-controls:8.0-r5" level="project" />
-    <orderEntry type="library" name="Maven: org.jfxtras:jfxtras-common:8.0-r5" level="project" />
-    <orderEntry type="library" name="Maven: org.jfxtras:jfxtras-fxml:8.0-r5" level="project" />
+    <orderEntry type="library" name="Maven: org.openjfx:javafx-controls:15" level="project" />
+    <orderEntry type="library" name="Maven: org.openjfx:javafx-controls:mac:15" level="project" />
+    <orderEntry type="library" name="Maven: org.openjfx:javafx-graphics:15" level="project" />
+    <orderEntry type="library" name="Maven: org.openjfx:javafx-fxml:15" level="project" />
+    <orderEntry type="library" name="Maven: org.openjfx:javafx-fxml:mac:15" level="project" />
+    <orderEntry type="library" name="Maven: org.openjfx:javafx-graphics:mac:12" level="project" />
+    <orderEntry type="library" name="Maven: org.openjfx:javafx-base:12" level="project" />
+    <orderEntry type="library" name="Maven: org.openjfx:javafx-base:mac:12" level="project" />
+    <orderEntry type="library" name="Maven: org.jfxtras:jfxtras-controls:11.0-r1-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.jfxtras:jfxtras-fxml:11.0-r1-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.jfxtras:jfxtras-common:11.0-r1-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-imaging:1.0-SNAPSHOT" level="project" />
-    <orderEntry type="library" name="Maven: org.fxmisc.easybind:easybind:1.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.controlsfx:controlsfx:8.40.14" level="project" />
-    <orderEntry type="library" name="Maven: commons-validator:commons-validator:1.6" level="project" />
-    <orderEntry type="library" name="Maven: commons-beanutils:commons-beanutils:1.9.2" level="project" />
-    <orderEntry type="library" name="Maven: commons-digester:commons-digester:1.8.1" level="project" />
+    <orderEntry type="library" name="Maven: org.fxmisc.easybind:easybind:1.0.4-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.controlsfx:controlsfx:12.0.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.openjfx:javafx-swing:11.0.2" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.openjfx:javafx-swing:mac:11.0.2" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.openjfx:javafx-media:11.0.2" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.openjfx:javafx-media:mac:11.0.2" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.openjfx:javafx-web:11.0.2" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.openjfx:javafx-web:mac:11.0.2" level="project" />
+    <orderEntry type="library" name="Maven: commons-validator:commons-validator:1.7" level="project" />
+    <orderEntry type="library" name="Maven: commons-beanutils:commons-beanutils:1.9.4" level="project" />
+    <orderEntry type="library" name="Maven: commons-digester:commons-digester:2.1" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.9" level="project" />
-    <orderEntry type="library" name="Maven: commons-io:commons-io:2.6" level="project" />
+    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-collections4:4.4" level="project" />
-    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.5" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.7" level="project" />
     <orderEntry type="library" name="Maven: org.hildan.fxgson:fx-gson:3.1.2" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:15.0" level="project" />
-    <orderEntry type="library" name="Maven: org.irods.jargon:jargon-core:4.3.0.1-RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.10" level="project" />
-    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
-    <orderEntry type="library" name="Maven: org.jglobus:gss:2.0.6" level="project" />
-    <orderEntry type="library" name="Maven: org.jglobus:jsse:2.0.6" level="project" />
-    <orderEntry type="library" name="Maven: org.jglobus:ssl-proxies:2.0.6" level="project" />
-    <orderEntry type="library" name="Maven: org.bouncycastle:bcprov-jdk16:1.45" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.9.5" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.9.5" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.9.0" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.22" level="project" />
+    <orderEntry type="library" name="Maven: org.irods.jargon:jargon-core:4.3.1.0-RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: commons-io:commons-io:2.6" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.12" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.9" level="project" />
+    <orderEntry type="library" name="Maven: org.jglobus:gss:2.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jglobus:jsse:2.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jglobus:ssl-proxies:2.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.bouncycastle:bcprov-jdk15on:1.50" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
-    <orderEntry type="library" name="Maven: com:panemu:tiwulfx:1.3-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: com.panemu:tiwulfx:1.3-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: org.apache.poi:poi:3.8" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.commons:commons-compress:1.18" level="project" />
-    <orderEntry type="library" name="Maven: com.github.ClemensFischer:FX-Map-Control:-f75082b7b2-1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.commons:commons-compress:1.20" level="project" />
+    <orderEntry type="library" name="Maven: com.github.ClemensFischer:FX-Map-Control:-998dde710f-1" level="project" />
+    <orderEntry type="library" name="Maven: com.github.ClemensFischer.FX-Map-Control:FxMapControl:-998dde710f-1" level="project" />
+    <orderEntry type="library" name="Maven: com.github.ClemensFischer.FX-Map-Control:SampleApplication:-998dde710f-1" level="project" />
     <orderEntry type="library" name="Maven: ch.qos.logback:logback-classic:1.2.1" level="project" />
     <orderEntry type="library" name="Maven: ch.qos.logback:logback-core:1.2.1" level="project" />
   </component>

--- a/Sanimal FX/pom.xml
+++ b/Sanimal FX/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.jfxtras</groupId>
             <artifactId>jfxtras-controls</artifactId>
-            <version>14-r1-SNAPSHOT</version>
+            <version>11.0-r1-SNAPSHOT</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-imaging -->
         <dependency>

--- a/Sanimal FX/src/main/java/model/util/FXMLLoaderUtils.java
+++ b/Sanimal FX/src/main/java/model/util/FXMLLoaderUtils.java
@@ -21,14 +21,14 @@ public class FXMLLoaderUtils
 	public static FXMLLoader loadFXML(String FXMLFileName)
 	{
 		// Create the loader
-		FXMLLoader loader = new FXMLLoader(Sanimal.class.getClass().getResource("/view/" + FXMLFileName));
+		FXMLLoader loader = new FXMLLoader(Sanimal.class.getResource("/view/" + FXMLFileName));
 
 		// Attempt to load the file. If we get an error throw an exception
 		try
 		{
 			loader.load();
 		}
-		catch (IOException exception)
+		catch (IOException | IllegalStateException exception)
 		{
 			SanimalData.getInstance().getErrorDisplay().printError("Could not load the FXML file for the file " + FXMLFileName + "!\n" + ExceptionUtils.getStackTrace(exception));
 			System.exit(-1);

--- a/Sanimal FX/src/main/resources/view/SanimalView.css
+++ b/Sanimal FX/src/main/resources/view/SanimalView.css
@@ -1,5 +1,5 @@
 .tab .tab-label {
-    -fx-skin: "com.sun.javafx.scene.control.skin.LabelSkin";
+    -fx-skin: "javafx.scene.control.skin.LabelSkin";
     -fx-background-color: transparent;
     -fx-alignment: CENTER;
     -fx-text-fill: -fx-text-base-color;


### PR DESCRIPTION
Problem: Maven build failure, jfxtras-controls version

When I run `mvn -U compile package` I see this:

```
[WARNING] The POM for org.jfxtras:jfxtras-controls:jar:14-r1-SNAPSHOT is missing, no dependency information available
...
[ERROR] Failed to execute goal on project SanimalFX: Could not resolve dependencies for project com.dslovikosky:SanimalFX:jar:1.0-SNAPSHOT: Could not find artifact org.jfxtras:jfxtras-controls:jar:14-r1-SNAPSHOT in sonatype (https://oss.sonatype.org/content/repositories/snapshots/) -> [Help 1]
```

Solution: Use the latest version (`11.0-r1-SNAPSHOT`) I could find on oss.sonatype.org - See:

https://oss.sonatype.org/content/repositories/snapshots/org/jfxtras/jfxtras-controls/

---

### Other things in this PR

- Fixed problem: loadFXML method throws IllegalStateException
- Fixed problem: Invalid -fx-skin attribute
- Updated IntelliJ Maven config
- Modified Travis job to use openjdk15
- Removed repo from Travis job. It should use the current repo.